### PR TITLE
Fix Gemini provider import and initialization

### DIFF
--- a/bin/wrp_client/providers/gemini.py
+++ b/bin/wrp_client/providers/gemini.py
@@ -7,8 +7,8 @@ from .base import BaseLLM, LLMReply, ToolDef
 from typing import List, Dict
 
 try:
-    from google import genai
-    from google.genai import types
+    import google.generativeai as genai
+    from google.generativeai import types
 except ImportError:
     genai = None
     types = None
@@ -35,7 +35,8 @@ class GeminiLLM(BaseLLM):
         if not api_key_value:
             raise ValueError("Gemini API Key not found. Please provide it in the config file or set GEMINI_API_KEY environment variable.")
 
-        self.client = genai.Client(api_key=api_key_value)
+        genai.configure(api_key=api_key_value)
+        self.client = genai.GenerativeModel(model_name)
         self.model_name = model_name
         
     async def chat(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "iowarp-mcps"
-version = "0.3.2"
+version = "0.3.3"
 description = "Open Source MCP Servers for Scientific Computing"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Fixes the Gemini provider ImportError issue by correcting the google-generativeai import and initialization.

## Changes
- Fix incorrect import from `google.genai` to `google.generativeai as genai`
- Update client initialization from deprecated `genai.Client()` to proper `genai.GenerativeModel()`
- Use `genai.configure()` to set API key before model initialization

## Fixes
Closes #151

## Test Plan
- [x] Verified google-generativeai package imports correctly
- [x] Tested script runs without import errors: `python3 bin/wrp.py --conf=bin/confs/Gemini.yaml`
- [x] Confirmed Gemini provider initializes properly

🤖 Generated with [Claude Code](https://claude.ai/code)