### PR TITLE
fix: Separate website build testing from deployment

### DIFF
--- a/.github/workflows/docs-and-website.yml
+++ b/.github/workflows/docs-and-website.yml
@@ -1,4 +1,4 @@
-name: Update Documentation and Deploy Website
+name: Update Documentation and Build Website
 
 on:
   push:
@@ -9,15 +9,12 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  pages: write
-  id-token: write
 
 jobs:
-  update-and-deploy:
+  # Job 1: Build and test documentation (runs on all branches/PRs)
+  build-docs:
+    name: Build Documentation
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     
     steps:
     - name: Checkout repository
@@ -41,7 +38,7 @@ jobs:
           uv sync
         fi
 
-    # Step 1: Update README files (for PRs to dev branch)
+    # Update README files (for PRs to dev branch)
     - name: Update MCP README files
       if: github.event_name == 'pull_request' && github.base_ref == 'dev'
       run: python3 scripts/readme_filler.py mcps
@@ -60,7 +57,7 @@ jobs:
           echo "No README changes to commit"
         fi
 
-    # Step 2: Generate Docusaurus documentation
+    # Generate and build documentation
     - name: Generate Docusaurus documentation
       run: |
         python3 scripts/generate_docs.py mcps docs
@@ -80,23 +77,16 @@ jobs:
       working-directory: ./docs
       run: npm run build
 
-    # Step 3: Deploy to GitHub Pages (only on main branch push)
-    - name: Setup Pages
+    # Store build artifacts for deployment job
+    - name: Upload build artifacts
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      uses: actions/configure-pages@v4
-
-    - name: Upload artifact
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        path: './docs/build'
+        name: docs-build
+        path: ./docs/build
+        retention-days: 1
 
-    - name: Deploy to GitHub Pages
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      id: deployment
-      uses: actions/deploy-pages@v4
-
-    # Step 4: Commit generated documentation (for workflow branch)
+    # Commit generated documentation (for workflow branch)
     - name: Commit generated documentation
       if: github.ref == 'refs/heads/workflow/docusaurus-for-webpage' && github.event_name == 'push'
       run: |
@@ -111,15 +101,55 @@ jobs:
           echo "No documentation changes to commit"
         fi
 
-    # Step 5: Summary
+    # Job Summary
     - name: Job Summary
       run: |
-        echo "## Documentation Update Summary" >> $GITHUB_STEP_SUMMARY
+        echo "## Documentation Build Summary" >> $GITHUB_STEP_SUMMARY
         echo "- ✅ Generated Docusaurus documentation" >> $GITHUB_STEP_SUMMARY
         echo "- ✅ Built website successfully" >> $GITHUB_STEP_SUMMARY
-        if [ "${{ github.ref }}" = "refs/heads/main" ] && [ "${{ github.event_name }}" = "push" ]; then
-          echo "- 🚀 Deployed to GitHub Pages" >> $GITHUB_STEP_SUMMARY
-        fi
         if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.base_ref }}" = "dev" ]; then
           echo "- 📝 Updated README files" >> $GITHUB_STEP_SUMMARY
         fi
+        if [ "${{ github.ref }}" = "refs/heads/main" ] && [ "${{ github.event_name }}" = "push" ]; then
+          echo "- 📦 Build artifacts ready for deployment" >> $GITHUB_STEP_SUMMARY
+        fi
+
+  # Job 2: Deploy to GitHub Pages (only runs on main branch pushes)
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build-docs
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    
+    permissions:
+      pages: write
+      id-token: write
+    
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: docs-build
+        path: ./build
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+
+    - name: Upload to GitHub Pages
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ./build
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
+
+    - name: Deployment Summary
+      run: |
+        echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
+        echo "- 🚀 Successfully deployed to GitHub Pages" >> $GITHUB_STEP_SUMMARY
+        echo "- 🔗 Website URL: ${{ steps.deployment.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problem
Every commit to dev, PRs, and feature branches show "This branch had an error being deployed" with failed GitHub Pages deployments, even though the build succeeds.

## Root Cause
The current workflow runs a single job with `github-pages` environment on all branches, but only conditionally deploys. GitHub still considers this a "failed deployment" when deployment steps are skipped.

## Solution
Split the workflow into two separate jobs:

### 1. `build-docs` (runs on all branches/PRs)
- ✅ Tests that documentation builds successfully
- ✅ Updates README files on dev PRs  
- ✅ Commits generated docs on workflow branch
- ❌ **No deployment environment** - no failed deployment errors

### 2. `deploy` (only runs on main branch pushes)  
- ✅ Downloads build artifacts from build-docs job
- ✅ Uses `github-pages` environment for actual deployment
- ✅ Only runs when we actually want to deploy

## Benefits
- 🚫 **No more "failed deployment" errors** on dev branches and PRs
- ✅ **Still tests builds** on all branches to catch issues early
- 🎯 **Clean separation** of concerns: build testing vs deployment
- 📊 **Better job summaries** with appropriate status messages

## Test Plan
1. Merge this PR to dev → should show successful build, no deployment attempt
2. Merge dev to main → should show successful build AND successful deployment
3. Create new PR → should show successful build, no deployment errors

🤖 Generated with [Claude Code](https://claude.ai/code)