### PR TITLE
Support agent framework backends

### DIFF
--- a/bin/confs/Opencode-example.yaml
+++ b/bin/confs/Opencode-example.yaml
@@ -1,0 +1,10 @@
+LLM:
+  Provider: opencode
+  model_name: anthropic/claude-sonnet-4-20250514
+  Provider_Config_Path: <absolute path to opencode config json>
+  MCP:
+    - Arxiv
+
+
+MCP:
+  - Arxiv

--- a/bin/confs/Opencode.yaml
+++ b/bin/confs/Opencode.yaml
@@ -1,0 +1,5 @@
+LLM:
+  Provider: opencode
+
+MCP:
+  - Arxiv

--- a/bin/confs/Opencode.yaml
+++ b/bin/confs/Opencode.yaml
@@ -1,5 +1,0 @@
-LLM:
-  Provider: opencode
-
-MCP:
-  - Arxiv

--- a/bin/wrp.py
+++ b/bin/wrp.py
@@ -11,7 +11,7 @@ sys.path.insert(0, sys.path[0] + '/..')
 
 from wrp_client.config import load_config
 from wrp_client.providers.factory import get_llm_adapter
-from wrp_client.mcp_manager import MCPManager, find_server_py
+from wrp_client.mcp_manager import WarpMCPManager, EmptyMCPManager, find_server_py
 
 
 async def async_main():
@@ -63,9 +63,16 @@ async def async_main():
 
         print(f"\n=== Connecting to {name} ===")
         try:
-            server_py = find_server_py(name)
-            manager = MCPManager(llm_adapter, verbose=verbose)
-            await manager.connect(server_py)
+            # Choose manager based on LLM's externally_managed_mcps flag
+            if getattr(llm_adapter, 'externally_managed_mcps', False):
+                manager = EmptyMCPManager(llm_adapter, verbose=verbose)
+                # For externally managed MCPs, we don't need a server script
+                await manager.connect("")
+            else:
+                server_py = find_server_py(name)
+                manager = WarpMCPManager(llm_adapter, verbose=verbose)
+                await manager.connect(server_py)
+            
             await manager.chat_loop()
         except FileNotFoundError as e:
             print(f"Error: {e}", file=sys.stderr)

--- a/bin/wrp.py
+++ b/bin/wrp.py
@@ -53,7 +53,7 @@ async def async_main():
     if not server_names:
         print("No MCP servers specified in the configuration file.", file=sys.stderr)
         sys.exit(1)
-        
+
     for server_name in server_names:
         # The manager can handle complex server configs if needed in the future
         if isinstance(server_name, dict):

--- a/bin/wrp_client/helpers.py
+++ b/bin/wrp_client/helpers.py
@@ -1,0 +1,56 @@
+
+def extract_mcp_tools(text, mcps):
+    """
+    Extract only MCP-specific tools from opencode tool listing text.
+
+    Removes built-in opencode tools and keeps only tools under novel MCP headers
+
+    Args:
+        text (str): The full tool listing text from opencode
+
+    Returns:
+        str: Filtered text containing only MCP-specific tools
+    """
+    lines = text.split('\n')
+
+    # Built-in tool names to remove
+    builtin_tools = {
+        "read", "write", "edit", "list", "glob", "grep",
+        "bash", "task",
+        "todowrite", "todoread",
+        "webfetch"
+    }
+
+    filtered_lines = []
+    skip_section = False
+
+    for line in lines:
+        # Check if this is a section header
+        if line.startswith('# '):
+            # TBD - More robust detection would be preferable
+
+            # Determine whether this section pertains MCP tools
+            skip_section = True
+
+            for mcp in mcps:
+                skip_section = (mcp.lower() not in line.strip().lower() and
+                                "mcp" not in line.strip().lower())
+
+            if skip_section:
+                continue
+
+        elif skip_section:
+            continue
+        elif ' - ' in line.strip():
+            # Extract tool name by going from start of line to ' - '
+            tool_name = line.strip().split(' - ')[0].strip()
+            # If tool name is in builtin tools, continue (skip this line)
+            if tool_name in builtin_tools:
+                continue
+        else:
+            # Skip other lines by default (e.g. other semantic LLM output)
+            continue
+
+        filtered_lines.append(line)
+
+    return '\n'.join(filtered_lines).strip()

--- a/bin/wrp_client/mcp_manager.py
+++ b/bin/wrp_client/mcp_manager.py
@@ -2,6 +2,7 @@ import json
 import asyncio
 import sys
 import os
+from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack
 from pathlib import Path
 from typing import List, Optional
@@ -24,16 +25,55 @@ def find_server_py(server_name: str) -> str:
     raise FileNotFoundError(f"Could not find server.py for {server_name}")
 
 
-class MCPManager:
+class MCPManager(ABC):
     """
-    Manages the connection and interaction with a single MCP server.
+    Abstract base class for managing MCP interactions.
     """
     def __init__(self, llm_adapter: BaseLLM, verbose: bool = False):
+        self.llm = llm_adapter
+        self.verbose = verbose
+
+    @abstractmethod
+    async def connect(self, server_script: str):
+        """Connect to MCP server(s)."""
+        pass
+
+    @abstractmethod
+    async def process_query(self, query: str) -> str:
+        """Process a user query and return a response."""
+        pass
+
+    async def chat_loop(self):
+        """Interactive chat loop"""
+        print(f"\nMCP Client Started! (type 'quit' to exit)")
+        try:
+            while True:
+                q = input("\nQuery: ").strip()
+                if q.lower() in ('quit', 'exit'):
+                    break
+                response_text = await self.process_query(q)
+                print(f"\n{response_text}")
+        except (KeyboardInterrupt, EOFError):
+            print("\nExiting...")
+        finally:
+            await self.cleanup()
+
+    @abstractmethod
+    async def cleanup(self):
+        """Clean up resources."""
+        pass
+
+
+class WarpMCPManager(MCPManager):
+    """
+    Manages the connection and interaction with a single MCP server.
+    This is the original MCPManager functionality.
+    """
+    def __init__(self, llm_adapter: BaseLLM, verbose: bool = False):
+        super().__init__(llm_adapter, verbose)
         self.session: Optional[ClientSession] = None
         self.exit_stack = AsyncExitStack()
-        self.llm = llm_adapter
         self.tools: List[ToolDef] = []
-        self.verbose = verbose
 
     async def connect(self, server_script: str):
         print(f"Starting server with stdio: {server_script}" if self.verbose else "")
@@ -120,19 +160,34 @@ class MCPManager:
         except Exception as e:
             return f"Error during LLM processing: {e}"
 
-    async def chat_loop(self):
-        print(f"\nMCP Client Started! (type 'quit' to exit)")
+    async def cleanup(self):
+        await self.exit_stack.aclose()
+
+
+class EmptyMCPManager(MCPManager):
+    """
+    Simplified MCP manager that assumes the LLM handles tool calls internally.
+    Used when MCPs are managed by an external agent framework.
+    """
+    def __init__(self, llm_adapter: BaseLLM, verbose: bool = False):
+        super().__init__(llm_adapter, verbose)
+
+    async def connect(self, server_script: str):
+        """No-op connection since MCPs are externally managed."""
+        if self.verbose:
+            print(f"EmptyMCPManager: Skipping connection to {server_script} (externally managed)")
+
+    async def process_query(self, query: str) -> str:
+        """Simple query processing that delegates to LLM's internal tool handling."""
+        messages = [{"role": "user", "content": query}]
+        
         try:
-            while True:
-                q = input("\nQuery: ").strip()
-                if q.lower() in ('quit', 'exit'):
-                    break
-                response_text = await self.process_query(q)
-                print(f"\n{response_text}")
-        except (KeyboardInterrupt, EOFError):
-            print("\nExiting...")
-        finally:
-            await self.cleanup()
+            # Assume the LLM handles tool calls internally
+            llm_reply = await self.llm.chat(messages, [])
+            return llm_reply.text
+        except Exception as e:
+            return f"Error during LLM processing: {e}"
 
     async def cleanup(self):
-        await self.exit_stack.aclose() 
+        """No cleanup needed for empty manager."""
+        pass 

--- a/bin/wrp_client/providers/base.py
+++ b/bin/wrp_client/providers/base.py
@@ -22,6 +22,7 @@ class BaseLLM(ABC):
     must implement. This allows the main application logic to interact with any
     LLM provider in a consistent, predictable way.
     """
+    externally_managed_mcps = False
     @abstractmethod
     async def chat(
         self, messages: List[Dict[str, str]], tools: List[ToolDef]

--- a/bin/wrp_client/providers/claudecode.py
+++ b/bin/wrp_client/providers/claudecode.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import subprocess
+import asyncio
+
+from ..helpers import extract_mcp_tools
+from .base import BaseLLM, LLMReply, ToolDef
+from typing import List, Dict
+from pathlib import Path
+
+
+class ClaudeCodeLLM(BaseLLM):
+    """Adapter for ClaudeCode agent wrapper"""
+    def __init__(self, model_name: str = "claude-3-haiku-20240307", api_key: str = None, **kwargs):
+        if "MCP" not in kwargs:
+            raise ValueError("ClaudeCode backend requires MCP specifications")
+
+        # TBD: Pass model name to local config during initialization
+        self.model_name = model_name
+        self.externally_managed_mcps = True
+        self.subproc_env = os.environ.copy()
+
+        # Set up listed MCPs within Claude Code
+        for mcp in kwargs["MCP"]:
+            try:
+                dir = mcp
+                executable = mcp.lower() + "-mcp"
+
+                # TODO - remove old MCPs before this
+                result = subprocess.run(["claude", "mcp", "add", mcp, "--",
+                                        "uv", f"--directory={os.path.dirname(os.path.abspath(__file__))}/../../../mcps/" + dir, "run", executable])
+            except subprocess.CalledProcessError as e:
+                print(f"Failed to add MCP {mcp} with exit code {e.returncode}.\
+                      \nError output: {e.stderr}")
+
+        print("Retrieving Claude Code tools...")
+        result = subprocess.run(
+            ["claude", "-p", "List all tools available to you, in an ESCAPED CODE BLOCK with the format\n# tool header 1\ntool1 - desc1\n...\n# tool header 2\ntoolN - desc2\n..."],
+            env=self.subproc_env,
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        all_tools = result.stdout
+
+        print(all_tools)
+        self.mcp_tools = extract_mcp_tools(all_tools, kwargs["MCP"])
+        print(f"\nConnected to Claude Code agent with model {self.model_name}. Available tools:\n{self.mcp_tools}")
+
+
+    async def chat(
+        self, messages: List[Dict[str, str]], tools: List[ToolDef]
+    ) -> LLMReply:
+        user_messages = [m['content'] for m in messages if m["role"] != "system"]        
+
+        # Continuous opencode session handles remembering previous msgs in interaction
+        # Just send the new msg
+        result = subprocess.run(
+            ["claude", "-p", user_messages[-1], "-c"],
+            env=self.subproc_env,
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        agent_stdout = result.stdout
+        agent_stderr = result.stderr
+
+        return LLMReply(text=agent_stdout, tool_calls=None)

--- a/bin/wrp_client/providers/factory.py
+++ b/bin/wrp_client/providers/factory.py
@@ -3,6 +3,7 @@ from .ollama import OllamaLLM
 from .openai import OpenAILLM
 from .claude import ClaudeLLM
 from .opencode import OpenCodeLLM
+from .claudecode import ClaudeCodeLLM
 
 PROVIDER_REGISTRY = {
     "gemini": GeminiLLM,
@@ -10,6 +11,7 @@ PROVIDER_REGISTRY = {
     "openai": OpenAILLM,
     "claude": ClaudeLLM,
     "opencode": OpenCodeLLM,
+    "claudecode": ClaudeCodeLLM,
 }
 
 def get_llm_adapter(provider_name: str, **kwargs):

--- a/bin/wrp_client/providers/factory.py
+++ b/bin/wrp_client/providers/factory.py
@@ -2,12 +2,14 @@ from .gemini import GeminiLLM
 from .ollama import OllamaLLM
 from .openai import OpenAILLM
 from .claude import ClaudeLLM
+from .opencode import OpenCodeLLM
 
 PROVIDER_REGISTRY = {
     "gemini": GeminiLLM,
     "ollama": OllamaLLM,
     "openai": OpenAILLM,
     "claude": ClaudeLLM,
+    "opencode": OpenCodeLLM,
 }
 
 def get_llm_adapter(provider_name: str, **kwargs):

--- a/bin/wrp_client/providers/opencode.py
+++ b/bin/wrp_client/providers/opencode.py
@@ -1,0 +1,131 @@
+import os
+import sys
+import subprocess
+import asyncio
+
+from .base import BaseLLM, LLMReply, ToolDef
+from typing import List, Dict
+from pathlib import Path
+
+# TODO: Make this user-configurable/generated
+OPENCODE_CONFIG_PATH = os.path.dirname(os.path.abspath(__file__)) + "/../../confs/custom-opencode-config.json"
+
+class OpenCodeLLM(BaseLLM):
+    """Adapter for OpenCode agent wrapper"""
+    def __init__(self, model_name: str = "claude-3-haiku-20240307", api_key: str = None, **kwargs):
+        if not os.path.exists(OPENCODE_CONFIG_PATH):
+            raise FileNotFoundError("Opencode config JSON not found at " + OPENCODE_CONFIG_PATH)
+        # TBD: Pass model name to local opencode config during initialization - currently, opencode defaults to model in pre-existing JSON
+        self.model_name = model_name
+        self.externally_managed_mcps = True
+        self.subproc_env = os.environ.copy()
+        self.subproc_env["OPENCODE_CONFIG"] = OPENCODE_CONFIG_PATH
+
+        result = subprocess.run(
+            ["opencode", "run", "-c", ":ist all tools available to you, along with their descriptions. Group the tools under headers that start with #. Use ' - ' to separate each tool's name from its description. Do not start tool lines wiht '-'"],
+            env=self.subproc_env,
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        all_tools = result.stdout
+
+        self.mcp_tools = extract_mcp_tools(all_tools)
+        print(f"\nConnected to opencode agent framework with model {self.model_name}. Available tools:\n{self.mcp_tools}")
+
+
+    async def chat(
+        self, messages: List[Dict[str, str]], tools: List[ToolDef]
+    ) -> LLMReply:
+        system_prompt = "You are a helpful assistant."
+        user_messages = [m['content'] for m in messages if m["role"] != "system"]        
+
+        # Continuous opencode session handles remembering previous msgs in interaction
+        # Just send the new msg
+        result = subprocess.run(
+            ["opencode", "run", "-c", user_messages[-1]],
+            env=self.subproc_env,
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        agent_stdout = result.stdout
+        agent_stderr = result.stderr
+
+        return LLMReply(text=agent_stdout, tool_calls=None)
+
+async def main():
+    llm = OpenCodeLLM()
+    msg1 = {"send hello world A": "send hello world B"}
+    messages=[msg1]
+    tools =[]
+    chat = await llm.chat(messages=messages, tools=tools)
+    print(chat)
+
+    print("done")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+def extract_mcp_tools(text):
+    """
+    Extract only MCP-specific tools from opencode tool listing text.
+
+    Removes built-in opencode tools and keeps only tools under novel MCP headers
+
+    Args:
+        text (str): The full tool listing text from opencode
+
+    Returns:
+        str: Filtered text containing only MCP-specific tools
+    """
+    lines = text.split('\n')
+
+    # Built-in opencode tool sections to remove
+    builtin_sections = {
+        "File Operations",
+        "Code Execution",
+        "Task Management",
+        "Web & Research"
+    }
+
+    # Built-in tool names to remove
+    builtin_tools = {
+        "read", "write", "edit", "list", "glob", "grep",
+        "bash", "task",
+        "todowrite", "todoread",
+        "webfetch"
+    }
+
+    filtered_lines = []
+    current_section = None
+    skip_section = False
+
+    for line in lines:
+        # Check if this is a section header
+        if line.startswith('# '):
+            section_name = line.strip()[2:]  # Remove '# ' and spaces
+            current_section = section_name
+            # TBD - Need more robust detection
+            skip_section = (not "arxiv" in line.strip().lower() and not "mcp" in line.strip().lower())
+
+            if skip_section:
+                continue
+
+        elif skip_section:
+            continue
+        elif ' - ' in line.strip():
+            # Extract tool name by going from start of line to ' - '
+            tool_name = line.strip().split(' - ')[0].strip()
+            # If tool name is in builtin tools, continue (skip this line)
+            if tool_name in builtin_tools:
+                continue
+        else:
+            # Skip other lines by default (e.g. other semantic LLM output)
+            continue
+
+        filtered_lines.append(line)
+
+    return '\n'.join(filtered_lines).strip()

--- a/bin/wrp_client/providers/opencode.py
+++ b/bin/wrp_client/providers/opencode.py
@@ -3,26 +3,26 @@ import sys
 import subprocess
 import asyncio
 
+from ..helpers import extract_mcp_tools
 from .base import BaseLLM, LLMReply, ToolDef
 from typing import List, Dict
 from pathlib import Path
 
-# TODO: Make this user-configurable/generated
-OPENCODE_CONFIG_PATH = os.path.dirname(os.path.abspath(__file__)) + "/../../confs/custom-opencode-config.json"
-
 class OpenCodeLLM(BaseLLM):
     """Adapter for OpenCode agent wrapper"""
     def __init__(self, model_name: str = "claude-3-haiku-20240307", api_key: str = None, **kwargs):
-        if not os.path.exists(OPENCODE_CONFIG_PATH):
-            raise FileNotFoundError("Opencode config JSON not found at " + OPENCODE_CONFIG_PATH)
-        # TBD: Pass model name to local opencode config during initialization - currently, opencode defaults to model in pre-existing JSON
+        if "Provider_Config_Path" not in kwargs:
+            raise ValueError("OpenCodeLLM requires Provider_Config_Path in YAML to point to opencode config JSON")
+
         self.model_name = model_name
         self.externally_managed_mcps = True
         self.subproc_env = os.environ.copy()
-        self.subproc_env["OPENCODE_CONFIG"] = OPENCODE_CONFIG_PATH
+        self.subproc_env["OPENCODE_CONFIG"] = kwargs["Provider_Config_Path"]
 
         result = subprocess.run(
-            ["opencode", "run", "-c", ":ist all tools available to you, along with their descriptions. Group the tools under headers that start with #. Use ' - ' to separate each tool's name from its description. Do not start tool lines wiht '-'"],
+            ["opencode", "run",
+             "List all tools available to you, in a code block with the format\n# tool header 1\ntool1 - desc1\n...\n# tool header 2\ntoolN - desc2\n...",
+             "--model=" + self.model_name],
             env=self.subproc_env,
             capture_output=True,
             text=True,
@@ -31,20 +31,18 @@ class OpenCodeLLM(BaseLLM):
 
         all_tools = result.stdout
 
-        self.mcp_tools = extract_mcp_tools(all_tools)
+        self.mcp_tools = extract_mcp_tools(all_tools, kwargs["MCP"])
         print(f"\nConnected to opencode agent framework with model {self.model_name}. Available tools:\n{self.mcp_tools}")
-
 
     async def chat(
         self, messages: List[Dict[str, str]], tools: List[ToolDef]
     ) -> LLMReply:
-        system_prompt = "You are a helpful assistant."
         user_messages = [m['content'] for m in messages if m["role"] != "system"]        
 
         # Continuous opencode session handles remembering previous msgs in interaction
         # Just send the new msg
         result = subprocess.run(
-            ["opencode", "run", "-c", user_messages[-1]],
+            ["opencode", "run", user_messages[-1], "-c"],
             env=self.subproc_env,
             capture_output=True,
             text=True,
@@ -55,77 +53,3 @@ class OpenCodeLLM(BaseLLM):
         agent_stderr = result.stderr
 
         return LLMReply(text=agent_stdout, tool_calls=None)
-
-async def main():
-    llm = OpenCodeLLM()
-    msg1 = {"send hello world A": "send hello world B"}
-    messages=[msg1]
-    tools =[]
-    chat = await llm.chat(messages=messages, tools=tools)
-    print(chat)
-
-    print("done")
-
-if __name__ == "__main__":
-    asyncio.run(main())
-
-def extract_mcp_tools(text):
-    """
-    Extract only MCP-specific tools from opencode tool listing text.
-
-    Removes built-in opencode tools and keeps only tools under novel MCP headers
-
-    Args:
-        text (str): The full tool listing text from opencode
-
-    Returns:
-        str: Filtered text containing only MCP-specific tools
-    """
-    lines = text.split('\n')
-
-    # Built-in opencode tool sections to remove
-    builtin_sections = {
-        "File Operations",
-        "Code Execution",
-        "Task Management",
-        "Web & Research"
-    }
-
-    # Built-in tool names to remove
-    builtin_tools = {
-        "read", "write", "edit", "list", "glob", "grep",
-        "bash", "task",
-        "todowrite", "todoread",
-        "webfetch"
-    }
-
-    filtered_lines = []
-    current_section = None
-    skip_section = False
-
-    for line in lines:
-        # Check if this is a section header
-        if line.startswith('# '):
-            section_name = line.strip()[2:]  # Remove '# ' and spaces
-            current_section = section_name
-            # TBD - Need more robust detection
-            skip_section = (not "arxiv" in line.strip().lower() and not "mcp" in line.strip().lower())
-
-            if skip_section:
-                continue
-
-        elif skip_section:
-            continue
-        elif ' - ' in line.strip():
-            # Extract tool name by going from start of line to ' - '
-            tool_name = line.strip().split(' - ')[0].strip()
-            # If tool name is in builtin tools, continue (skip this line)
-            if tool_name in builtin_tools:
-                continue
-        else:
-            # Skip other lines by default (e.g. other semantic LLM output)
-            continue
-
-        filtered_lines.append(line)
-
-    return '\n'.join(filtered_lines).strip()


### PR DESCRIPTION
Add support for using ClaudeCode and opencode agent frameworks as model providers for Warp.

Because both of these frameworks natively support MCP integration on their own, Warp's MCP startup/shutdown/tool listing is disabled when the LLM provider has the `externally_managed_mcps` attribute.

These don't currently work with the integration tests for unclear reasons that may have to do with how commands are passed through multiple layers of subprocesses